### PR TITLE
Update virtual-module-webpack-plugin to 0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "glob": "^7.1.1",
     "lodash": "^4.17.4",
-    "virtual-module-webpack-plugin": "^0.1.3",
+    "virtual-module-webpack-plugin": "^0.3.0",
     "yaml-js": "^0.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
For this module to work with Webpack > 2.6, `v0.3` or above of the [`virtual-module-webpack-plugin`](https://github.com/rmarscher/virtual-module-webpack-plugin) must be used. This updates the dependency to `0.3.0` in the package.json so that this module works with Webpack > 2.6.

[`virtual-module-webpack-plugin` changelog](https://github.com/rmarscher/virtual-module-webpack-plugin/blob/master/CHANGELOG.md#changed)