### PR TITLE
upgrade virtual-module-webpack-plugin to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "glob": "^7.1.1",
     "lodash": "^4.17.4",
-    "virtual-module-webpack-plugin": "^0.3.0",
+    "virtual-module-webpack-plugin": "^0.4.1",
     "yaml-js": "^0.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This module currently does not work with webpack 4. This upgrades `virtual-module-webpack-plugin` so that it does.